### PR TITLE
fix: add configurable deduplication path for DeduplicationHandler

### DIFF
--- a/config/channels.php
+++ b/config/channels.php
@@ -8,6 +8,7 @@ return [
             'driver' => config('laravel_log_errors_to_mail.email_driver'),
             'recipient' => config('laravel_log_errors_to_mail.recipient'),
             'deduplicate' => config('laravel_log_errors_to_mail.deduplicate', true),
+            'deduplicate_path' => config('laravel_log_errors_to_mail.deduplicate_path', storage_path('logs/deduplicate.log')),
             'level' => config('laravel_log_errors_to_mail.log_level', \Psr\Log\LogLevel::ERROR),
         ],
     ],

--- a/config/laravel_log_errors_to_mail.php
+++ b/config/laravel_log_errors_to_mail.php
@@ -7,5 +7,7 @@ return [
 
     'deduplicate' => env('LOG_ERROR_TO_MAIL_DEDUPLICATE', true),
 
+    'deduplicate_path' => env('LOG_ERROR_TO_MAIL_DEDUPLICATE_PATH', storage_path('logs/deduplicate.log')),
+
     'log_level' => env('LOG_ERROR_TO_MAIL_LEVEL', \Psr\Log\LogLevel::ERROR),
 ];

--- a/src/Monolog/EmailHandler.php
+++ b/src/Monolog/EmailHandler.php
@@ -74,7 +74,7 @@ class EmailHandler implements HandlerInterface, ProcessableHandlerInterface
                 $deduplicationHandler = new DeduplicationHandler(
                     $mailHandler,
                     // Put the deduplication store into the tests directory
-                    (app()->runningUnitTests() ? __DIR__ . '/../../tests/deduplicate.log' : null),
+                    (app()->runningUnitTests() ? __DIR__ . '/../../tests/deduplicate.log' : config('laravel_log_errors_to_mail.deduplicate_path')),
                     // try to deduplicate all log levels.
                     Level::Debug
                 );


### PR DESCRIPTION
This PR makes the deduplication file path configurable via the `laravel_log_errors_to_mail.deduplicate_path` config key.
Previously, the deduplication log path was [set to null outside of unit tests](https://github.com/portavice/laravel-log-errors-to-mail/blob/main/src/Monolog/EmailHandler.php#L77), which effectively disabled deduplication in production environments.

Changes:
- Introduced a new `deduplicate_path` config value in `config/laravel_log_errors_to_mail.php`, defaulting to `storage/logs/deduplicate.log`.
- Referenced this path in the `DeduplicationHandler` initialization within `EmailHandler`.
- Passed the same value through `config/channels.php` to maintain compatibility with Laravel's logging channel configuration.

This ensures that deduplication works consistently in all environments, not just during testing.