### PR TITLE
feat: Add configurable deduplication time and bubble

### DIFF
--- a/config/channels.php
+++ b/config/channels.php
@@ -8,7 +8,6 @@ return [
             'driver' => config('laravel_log_errors_to_mail.email_driver'),
             'recipient' => config('laravel_log_errors_to_mail.recipient'),
             'deduplicate' => config('laravel_log_errors_to_mail.deduplicate', true),
-            'deduplicate_path' => config('laravel_log_errors_to_mail.deduplicate_path', storage_path('logs/deduplicate.log')),
             'level' => config('laravel_log_errors_to_mail.log_level', \Psr\Log\LogLevel::ERROR),
         ],
     ],

--- a/config/laravel_log_errors_to_mail.php
+++ b/config/laravel_log_errors_to_mail.php
@@ -9,5 +9,9 @@ return [
 
     'deduplicate_path' => env('LOG_ERROR_TO_MAIL_DEDUPLICATE_PATH', storage_path('logs/deduplicate.log')),
 
+    'deduplicate_time' => env('LOG_ERROR_TO_MAIL_DEDUPLICATE_TIME', 60),
+
+    'deduplicate_bubble' => env('LOG_ERROR_TO_MAIL_DEDUPLICATE_BUBBLE', true),
+
     'log_level' => env('LOG_ERROR_TO_MAIL_LEVEL', \Psr\Log\LogLevel::ERROR),
 ];

--- a/src/Monolog/EmailHandler.php
+++ b/src/Monolog/EmailHandler.php
@@ -76,7 +76,9 @@ class EmailHandler implements HandlerInterface, ProcessableHandlerInterface
                     // Put the deduplication store into the tests directory
                     (app()->runningUnitTests() ? __DIR__ . '/../../tests/deduplicate.log' : config('laravel_log_errors_to_mail.deduplicate_path')),
                     // try to deduplicate all log levels.
-                    Level::Debug
+                    Level::Debug,
+                    config('laravel_log_errors_to_mail.deduplicate_time', 60),
+                    config('laravel_log_errors_to_mail.deduplicate_bubble', true)
                 );
             } else {
                 $deduplicationHandler = $mailHandler;


### PR DESCRIPTION
This PR introduces two new configuration options for error log deduplication:

- `deduplicate_time`: Controls the deduplication window period (default: `60` seconds)
- `deduplicate_bubble`: Determines if messages should propagate to other handlers (default: `true`)

Changes:

- Removed redundant `deduplicate_path` from `channels.php` since it's only used internally
- Added new config entries with environment variable support
- Updated `DeduplicationHandler` initialization to use config values directly
- Maintained backward compatibility with default values

These changes give users more control over deduplication behavior while keeping the existing defaults.